### PR TITLE
BE: Add missing log_info method to IntegrationLogger (PR #46)

### DIFF
--- a/src/integration/utils/logger.py
+++ b/src/integration/utils/logger.py
@@ -44,6 +44,22 @@ class IntegrationLogger:
             console_handler.setFormatter(formatter)
             self.logger.addHandler(console_handler)
     
+    def log_info(self, message: str, details: Optional[Dict[str, Any]] = None) -> None:
+        """Log informational message.
+        
+        Args:
+            message: Informational message
+            details: Optional additional details
+        """
+        self._log_json_event(
+            event_type="info",
+            data={
+                "message": message,
+                "details": details or {}
+            }
+        )
+        self.logger.info(message)
+    
     def log_webhook(self, payload: Dict[str, Any], status_code: int, response: Dict[str, Any]) -> None:
         """Log incoming webhook request and response.
         


### PR DESCRIPTION
This PR adds the missing log_info method to the IntegrationLogger class, which is needed by PR #46 from the INT team.\n\nFixes failing tests in the paper trading risk integration.\n\nRefs #46