### PR TITLE
BE: Add runtime configuration files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,7 @@ Thumbs.db
 communication/inbox/*/archive/
 
 # Communication messages
-communication/inbox/*/*.md 
+communication/inbox/*/*.md
+
+# Runtime configuration files
+config/risk_parameters.json 


### PR DESCRIPTION
This PR updates the .gitignore file to exclude runtime configuration files like risk_parameters.json that are generated at runtime and should not be committed to the repository.