### PR TITLE
BE: Update gitignore to ignore config directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,5 +58,8 @@ communication/inbox/*/archive/
 # Communication messages
 communication/inbox/*/*.md
 
+# Runtime configuration files
+config/
+
 # Temporary backups
 temp_backup/ 


### PR DESCRIPTION
This PR updates the .gitignore file to ignore the entire 'config/' directory, which contains runtime-generated configuration files like risk_parameters.json. This prevents accidental commits of environment-specific settings.