### PR TITLE
FE: Fix verify-and-start script logic for node_modules check

### DIFF
--- a/communication/inbox/PM/Msg-FE-To-PM-Seq003-May10.md
+++ b/communication/inbox/PM/Msg-FE-To-PM-Seq003-May10.md
@@ -1,0 +1,45 @@
+<message>
+<id>Msg-FE-To-PM-Seq003-May10-e1g2h3</id>
+<sender>FE</sender>
+<recipient>PM</recipient>
+<cc>QA</cc>
+<type>TASK_UPDATE</type>
+<subject>Frontend Environment Verification Tool Tested and Updated</subject>
+<reference>Msg-PM-To-FE-Seq001-May10, Msg-QA-To-FE-Seq001-May10-Frontend-Environment-Issues</reference>
+<related_artifacts>
+  Branch: FE/fix/env-verification-testing
+  Script: /workspace/Viewzenix1/src/frontend/verify-and-start.js
+  Commit: 68997f9f
+</related_artifacts>
+<content>
+I have tested the `verify-and-start` tools (merged in PR #141) to address the critical frontend environment issues reported.
+
+## Test Results:
+
+1.  **Script Execution**: Successfully ran `verify-and-start.bat` and `verify-and-start.js`.
+2.  **Issue Detection**: The script correctly identified missing `node_modules` and backend API unavailability.
+3.  **Auto-Fix**: It successfully ran `npm install` to attempt fixing dependencies and enabled the mock API setting in `.env` due to backend unavailability.
+4.  **Logic Improvement**: I identified and fixed a logic issue where the script reported missing packages even after `npm install` succeeded. It now correctly re-verifies packages post-installation.
+
+## Instructions for QA:
+
+To set up and verify the frontend environment, please:
+
+1.  Navigate to the frontend directory: `cd /workspace/Viewzenix1/src/frontend`
+2.  Run the verification script appropriate for your OS:
+    *   Windows Batch: `.\verify-and-start.bat`
+    *   Windows PowerShell: `.\verify-and-start.ps1`
+    *   macOS/Linux: `./verify-and-start.sh` (Ensure executable: `chmod +x verify-and-start.sh`)
+3.  The script will check prerequisites, attempt fixes (like running `npm install`), and report its findings.
+4.  If all critical checks pass, it will attempt to start the application (`npm start`).
+5.  If issues persist, the script output will provide details.
+
+Please refer to `/workspace/Viewzenix1/src/frontend/README_FRONTEND_VERIFICATION.md` for more details.
+
+This improved script should resolve the reported startup issues (ENV-3, ENV-4). The latest fix has been committed to the `FE/fix/env-verification-testing` branch.
+
+Estimated effort used: 1 PU (including testing and script fix)
+
+I will create a PR for this fix shortly.
+</content>
+</message> 

--- a/communication/inbox/QA/Msg-FE-To-QA-Seq003-May10.md
+++ b/communication/inbox/QA/Msg-FE-To-QA-Seq003-May10.md
@@ -1,0 +1,44 @@
+<message>
+<id>Msg-FE-To-QA-Seq003-May10-e1g2h3</id>
+<sender>FE</sender>
+<recipient>QA</recipient>
+<cc>PM</cc>
+<type>TASK_UPDATE</type>
+<subject>Frontend Environment Verification Tool Tested and Updated - Instructions Included</subject>
+<reference>Msg-PM-To-FE-Seq001-May10, Msg-QA-To-FE-Seq001-May10-Frontend-Environment-Issues</reference>
+<related_artifacts>
+  Branch: FE/fix/env-verification-testing
+  Script: /workspace/Viewzenix1/src/frontend/verify-and-start.js
+  Commit: 68997f9f
+</related_artifacts>
+<content>
+I have tested the `verify-and-start` tools (merged in PR #141) to address the critical frontend environment issues you reported.
+
+## Test Results:
+
+1.  **Script Execution**: Successfully ran `verify-and-start.bat` and `verify-and-start.js`.
+2.  **Issue Detection**: The script correctly identified missing `node_modules` and backend API unavailability.
+3.  **Auto-Fix**: It successfully ran `npm install` to attempt fixing dependencies and enabled the mock API setting in `.env` due to backend unavailability.
+4.  **Logic Improvement**: I identified and fixed a logic issue where the script reported missing packages even after `npm install` succeeded. It now correctly re-verifies packages post-installation.
+
+## Instructions for Your Setup:
+
+To set up and verify the frontend environment, please:
+
+1.  Ensure you have pulled the latest `develop` branch which includes the verification tools.
+2.  Navigate to the frontend directory: `cd /workspace/Viewzenix1/src/frontend`
+3.  Run the verification script appropriate for your OS:
+    *   Windows Batch: `.\verify-and-start.bat`
+    *   Windows PowerShell: `.\verify-and-start.ps1`
+    *   macOS/Linux: `./verify-and-start.sh` (Ensure executable: `chmod +x verify-and-start.sh`)
+4.  The script will check prerequisites, attempt fixes (like running `npm install`), and report its findings.
+5.  If all critical checks pass, it will attempt to start the application (`npm start`).
+6.  If issues persist, the script output will provide details.
+
+Please refer to `/workspace/Viewzenix1/src/frontend/README_FRONTEND_VERIFICATION.md` for more details.
+
+This improved script should resolve the reported startup issues (ENV-3, ENV-4). The latest fix has been committed to the `FE/fix/env-verification-testing` branch.
+
+Let me know if you encounter any problems using the script.
+</content>
+</message> 

--- a/src/frontend/verify-and-start.js
+++ b/src/frontend/verify-and-start.js
@@ -106,56 +106,71 @@ function checkNodeModules() {
   return new Promise((resolve) => {
     console.log(`${colors.cyan}Checking node_modules...${colors.reset}`);
     const nodeModulesPath = path.join(process.cwd(), 'node_modules');
-    
+    let needsInstall = false;
+    let initialCheckPassed = false;
+
     if (!fs.existsSync(nodeModulesPath)) {
       issues.push("node_modules directory not found - will run 'npm install'");
       console.log(`${colors.red}✗ node_modules directory not found${colors.reset}`);
+      needsInstall = true;
+    } else {
+      console.log(`${colors.green}✓ node_modules directory found${colors.reset}`);
+      // Check for critical packages initially
+      const criticalPackages = ['react', 'react-dom', 'react-scripts'];
+      const missingPackages = criticalPackages.filter(pkg => {
+        const pkgPath = path.join(nodeModulesPath, pkg);
+        return !fs.existsSync(pkgPath);
+      });
+
+      if (missingPackages.length > 0) {
+        issues.push(`Critical packages missing from node_modules: ${missingPackages.join(', ')}`);
+        console.log(`${colors.red}✗ Critical packages missing: ${missingPackages.join(', ')}${colors.reset}`);
+        needsInstall = true;
+      } else {
+        passes.push("All critical packages installed in node_modules");
+        initialCheckPassed = true; // Packages were present initially
+      }
+    }
+
+    // Run install if needed
+    if (needsInstall) {
       console.log(`${colors.yellow}⚠ Attempting to fix: Running 'npm install'...${colors.reset}`);
-      
       try {
         console.log(`Installing dependencies...`);
         execSync('npm install', { stdio: 'inherit' });
-        fixes.push("Installed dependencies with 'npm install'");
-        console.log(`${colors.green}✓ Dependencies installed successfully${colors.reset}`);
+        fixes.push("Attempted dependency installation with 'npm install'");
+        console.log(`${colors.green}✓ Dependency installation command executed${colors.reset}`);
+
+        // Re-verify critical packages after installation
+        console.log(`${colors.cyan}Re-verifying critical packages after install...${colors.reset}`);
+        const criticalPackages = ['react', 'react-dom', 'react-scripts'];
+        const missingPackagesAfterInstall = criticalPackages.filter(pkg => {
+           const pkgPath = path.join(nodeModulesPath, pkg);
+           return !fs.existsSync(pkgPath);
+        });
+
+        if (missingPackagesAfterInstall.length > 0) {
+           // If packages are still missing, keep the original issue
+           console.log(`${colors.red}✗ Critical packages still missing after install: ${missingPackagesAfterInstall.join(', ')}${colors.reset}`);
+        } else {
+           console.log(`${colors.green}✓ All critical packages verified after install${colors.reset}`);
+           // Remove the previous 'missing packages' issue if it existed
+           const issueIndex = issues.findIndex(issue => issue.startsWith('Critical packages missing'));
+           if (issueIndex > -1) {
+               issues.splice(issueIndex, 1);
+           }
+           // Add a pass if it wasn't already passed initially
+           if (!initialCheckPassed) {
+                passes.push("All critical packages installed in node_modules (after install)");
+           }
+        }
+
       } catch (error) {
         issues.push(`Failed to install dependencies: ${error.message}`);
         console.log(`${colors.red}✗ Failed to install dependencies: ${error.message}${colors.reset}`);
       }
-      
-      return resolve();
     }
-    
-    console.log(`${colors.green}✓ node_modules directory found${colors.reset}`);
-    
-    // Check for critical packages
-    const criticalPackages = ['react', 'react-dom', 'react-scripts'];
-    const missingPackages = [];
-    
-    for (const pkg of criticalPackages) {
-      const pkgPath = path.join(nodeModulesPath, pkg);
-      if (!fs.existsSync(pkgPath)) {
-        missingPackages.push(pkg);
-      }
-    }
-    
-    if (missingPackages.length > 0) {
-      issues.push(`Critical packages missing from node_modules: ${missingPackages.join(', ')}`);
-      console.log(`${colors.red}✗ Critical packages missing: ${missingPackages.join(', ')}${colors.reset}`);
-      console.log(`${colors.yellow}⚠ Attempting to fix: Running 'npm install'...${colors.reset}`);
-      
-      try {
-        console.log(`Installing dependencies...`);
-        execSync('npm install', { stdio: 'inherit' });
-        fixes.push("Reinstalled dependencies to fix missing packages");
-        console.log(`${colors.green}✓ Dependencies reinstalled successfully${colors.reset}`);
-      } catch (error) {
-        issues.push(`Failed to reinstall dependencies: ${error.message}`);
-        console.log(`${colors.red}✗ Failed to reinstall dependencies: ${error.message}${colors.reset}`);
-      }
-    } else {
-      passes.push("All critical packages installed in node_modules");
-    }
-    
+
     resolve();
   });
 }


### PR DESCRIPTION
This PR fixes a logic issue in the erify-and-start.js script where it could incorrectly report missing node_modules packages even after successfully running 
pm install. It now re-verifies package existence post-install.\n\nAddresses feedback from testing the script as requested in Msg-PM-To-FE-Seq001-May10. Includes notification messages to PM and QA.