### PR TITLE
BE: Update .gitignore for DB and config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,7 +75,12 @@ communication/inbox/*/archive/
 # communication/inbox/*/*.md  <- Removing this, messages should be tracked if explicitly added
 
 # Runtime configuration files
-# config/ <- Removing this if runtime config needs tracking
+config/
 
 # Temporary backups
-temp_backup/ 
+temp_backup/
+
+# Database files
+*.db
+*.sqlite
+*.sqlite3 


### PR DESCRIPTION
Updates .gitignore to correctly ignore SQLite database files (*.db, *.sqlite, *.sqlite3) and the runtime 'config/' directory. This prevents accidental commits of database files and environment-specific configurations.